### PR TITLE
更新:ksubdomain版本1.9.9->2.4.0

### DIFF
--- a/bucket/GooFuzz.json
+++ b/bucket/GooFuzz.json
@@ -14,8 +14,8 @@
         "@popd' -Encoding Ascii"
     ],
     "post_install": [
-        "Move-Item -Path \"$dir\\GooFuzz v.$version\\*\" -Destination \"$dir\\\"",
-        "Remove-Item \"$dir\\GooFuzz v.$version\" -Force -Recurse"
+        "Move-Item -Path \"$dir\\GooFuzz.v.$version\\*\" -Destination \"$dir\\\"",
+        "Remove-Item \"$dir\\GooFuzz.v.$version\" -Force -Recurse"
     ],
     "bin": "GooFuzz.bat",
     "checkver": "github",

--- a/bucket/ksubdomain.json
+++ b/bucket/ksubdomain.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.9.9",
+    "version": "2.4.0",
     "description": "Subdomain enumeration tool, asynchronous dns packets, use pcap to scan 1600,000 subdomains in 1 second(Scoop bucket by arch3rpro)",
     "homepage": "https://github.com/boy-hack/ksubdomain",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/boy-hack/ksubdomain/releases/download/v1.9.9/KSubdomain-windows.tar",
-            "hash": "18ad7ca239c513f7865e4e46d14b9bad510b12b6d7b5cb070d0d6b15db9c34bc"
+            "url": "https://github.com/boy-hack/ksubdomain/releases/download/v2.4.0/KSubdomain-v2.4.0-windows-amd64.zip",
+            "hash": "fb1e281ec7115bca038ee62167f363cbb3504916bc54a6f7ffe8237e19841b53"
         }
     },
     "bin": "ksubdomain.exe",
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/boy-hack/ksubdomain/releases/download/v$version/KSubdomain-windows.tar"
+                "url": "https://github.com/boy-hack/ksubdomain/releases/download/v$version/KSubdomain-v$version-windows-amd64.zip"
             }
         }
     }

--- a/bucket/observerward.json
+++ b/bucket/observerward.json
@@ -6,7 +6,7 @@
     "notes": "config location: $env:AppData/observer_ward",
     "url": "https://github.com/emo-crab/observer_ward/releases/download/v2026.4.8/observer_ward_v2026.4.8_i686-pc-windows-msvc.zip",
     "hash": "aa7874bd40a1980f05b7c9a43ca24e321dae7971b8fde9c837448f9c5da697ce",
-    "bin": "observer_ward.exe",
+    "bin": "i686-pc-windows-msvc.exe",
     "checkver": {
         "github": "https://github.com/emo-crab/observer_ward"
     },


### PR DESCRIPTION
ksubdomain的版本下载路径发生变化，似乎无法自动更新到最新版本。